### PR TITLE
Allow custom labels and emojis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 pubspec.lock
 
 .idea/
+.vscode/

--- a/lib/src/component_pagination.dart
+++ b/lib/src/component_pagination.dart
@@ -13,6 +13,16 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
   /// Custom id for this instance of paginator that different paginators could be recognized.
   late final String customPreId;
 
+  final String firstLabel;
+  final String prevLabel;
+  final String nextLabel;
+  final String lastLabel;
+
+  final IEmoji? firstEmoji;
+  final IEmoji? prevEmoji;
+  final IEmoji? nextEmoji;
+  final IEmoji? lastEmoji;
+
   /// Current page that paginator is on
   @override
   int currentPage = 1;
@@ -21,7 +31,17 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
   late ComponentMessageBuilder builder;
 
   /// Creates new paginator using interactions
-  ComponentPaginationAbstract(this.interactions) {
+  ComponentPaginationAbstract(
+    this.interactions, {
+    this.firstLabel = '<<',
+    this.prevLabel = '<',
+    this.nextLabel = '>',
+    this.lastLabel = '>>',
+    this.firstEmoji,
+    this.prevEmoji,
+    this.nextEmoji,
+    this.lastEmoji,
+  }) {
     customPreId = randomAlpha(10);
   }
 
@@ -29,7 +49,7 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
   @override
   ComponentMessageBuilder initMessageBuilder() {
     final firstPageButtonId = "${customPreId}firstPage";
-    final firstPageButton = ButtonBuilder("<<", firstPageButtonId, ComponentStyle.secondary);
+    final firstPageButton = ButtonBuilder(firstLabel, firstPageButtonId, ComponentStyle.secondary, emoji: firstEmoji);
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == firstPageButtonId).listen((event) async {
       await event.acknowledge();
 
@@ -38,7 +58,7 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
     });
 
     final previousPageButtonId = "${customPreId}previousPage";
-    final previousPageButton = ButtonBuilder("<", previousPageButtonId, ComponentStyle.secondary);
+    final previousPageButton = ButtonBuilder(prevLabel, previousPageButtonId, ComponentStyle.secondary, emoji: prevEmoji);
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == previousPageButtonId).listen((event) async {
       await event.acknowledge();
 
@@ -47,7 +67,7 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
     });
 
     final nextPageButtonId = "${customPreId}nextPage";
-    final nextPageButton = ButtonBuilder(">", nextPageButtonId, ComponentStyle.secondary);
+    final nextPageButton = ButtonBuilder(nextLabel, nextPageButtonId, ComponentStyle.secondary, emoji: nextEmoji);
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == nextPageButtonId).listen((event) async {
       await event.acknowledge();
 
@@ -56,7 +76,7 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
     });
 
     final lastPageButtonId = "${customPreId}lastPage";
-    final lastPageButton = ButtonBuilder(">>", lastPageButtonId, ComponentStyle.secondary);
+    final lastPageButton = ButtonBuilder(lastLabel, lastPageButtonId, ComponentStyle.secondary, emoji: lastEmoji);
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == lastPageButtonId).listen((event) async {
       await event.acknowledge();
 
@@ -103,7 +123,27 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
 /// [getMessageBuilderForPage] needs to be implemented in order to work.
 abstract class ComponentPaginationBase extends ComponentPaginationAbstract {
   /// Creates instance of [ComponentPaginationBase]
-  ComponentPaginationBase(IInteractions interactions) : super(interactions);
+  ComponentPaginationBase(
+    IInteractions interactions, {
+    String firstLabel = '<<',
+    String prevLabel = '<',
+    String nextLabel = '>',
+    String lastLabel = '>>',
+    IEmoji? firstEmoji,
+    IEmoji? prevEmoji,
+    IEmoji? nextEmoji,
+    IEmoji? lastEmoji,
+  }) : super(
+          interactions,
+          firstLabel: firstLabel,
+          prevLabel: prevLabel,
+          nextLabel: nextLabel,
+          lastLabel: lastLabel,
+          firstEmoji: firstEmoji,
+          prevEmoji: prevEmoji,
+          nextEmoji: nextEmoji,
+          lastEmoji: lastEmoji,
+        );
 
   @override
   FutureOr<void> updatePage(int page, ComponentMessageBuilder currentBuilder, IButtonInteractionEvent target) {
@@ -120,7 +160,28 @@ class EmbedComponentPagination extends ComponentPaginationBase {
   final List<EmbedBuilder> embeds;
 
   /// Creates instance of [EmbedComponentPagination]
-  EmbedComponentPagination(IInteractions interactions, this.embeds) : super(interactions);
+  EmbedComponentPagination(
+    IInteractions interactions,
+    this.embeds, {
+    String firstLabel = '<<',
+    String prevLabel = '<',
+    String nextLabel = '>',
+    String lastLabel = '>>',
+    IEmoji? firstEmoji,
+    IEmoji? prevEmoji,
+    IEmoji? nextEmoji,
+    IEmoji? lastEmoji,
+  }) : super(
+          interactions,
+          firstLabel: firstLabel,
+          prevLabel: prevLabel,
+          nextLabel: nextLabel,
+          lastLabel: lastLabel,
+          firstEmoji: firstEmoji,
+          prevEmoji: prevEmoji,
+          nextEmoji: nextEmoji,
+          lastEmoji: lastEmoji,
+        );
 
   @override
   ComponentMessageBuilder getMessageBuilderForPage(int page, ComponentMessageBuilder currentBuilder) => currentBuilder..embeds = [embeds[page - 1]];
@@ -135,7 +196,28 @@ class SimpleComponentPagination extends ComponentPaginationBase {
   final List<String> contentPages;
 
   /// Creates instance of [SimpleComponentPagination]
-  SimpleComponentPagination(IInteractions interactions, this.contentPages) : super(interactions);
+  SimpleComponentPagination(
+    IInteractions interactions,
+    this.contentPages, {
+    String firstLabel = '<<',
+    String prevLabel = '<',
+    String nextLabel = '>',
+    String lastLabel = '>>',
+    IEmoji? firstEmoji,
+    IEmoji? prevEmoji,
+    IEmoji? nextEmoji,
+    IEmoji? lastEmoji,
+  }) : super(
+          interactions,
+          firstLabel: firstLabel,
+          prevLabel: prevLabel,
+          nextLabel: nextLabel,
+          lastLabel: lastLabel,
+          firstEmoji: firstEmoji,
+          prevEmoji: prevEmoji,
+          nextEmoji: nextEmoji,
+          lastEmoji: lastEmoji,
+        );
 
   @override
   ComponentMessageBuilder getMessageBuilderForPage(int page, ComponentMessageBuilder currentBuilder) => currentBuilder..content = contentPages[page - 1];

--- a/lib/src/component_pagination.dart
+++ b/lib/src/component_pagination.dart
@@ -31,6 +31,8 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
   late ComponentMessageBuilder builder;
 
   /// Creates new paginator using interactions
+  ///
+  /// The `*Label` and `*Emoji` parameters control the emojis and labels used for the pagination buttons.
   ComponentPaginationAbstract(
     this.interactions, {
     this.firstLabel = '<<',
@@ -123,6 +125,8 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
 /// [getMessageBuilderForPage] needs to be implemented in order to work.
 abstract class ComponentPaginationBase extends ComponentPaginationAbstract {
   /// Creates instance of [ComponentPaginationBase]
+  ///
+  /// The `*Label` and `*Emoji` parameters control the emojis and labels used for the pagination buttons.
   ComponentPaginationBase(
     IInteractions interactions, {
     String firstLabel = '<<',
@@ -160,6 +164,8 @@ class EmbedComponentPagination extends ComponentPaginationBase {
   final List<EmbedBuilder> embeds;
 
   /// Creates instance of [EmbedComponentPagination]
+  ///
+  /// The `*Label` and `*Emoji` parameters control the emojis and labels used for the pagination buttons.
   EmbedComponentPagination(
     IInteractions interactions,
     this.embeds, {
@@ -196,6 +202,8 @@ class SimpleComponentPagination extends ComponentPaginationBase {
   final List<String> contentPages;
 
   /// Creates instance of [SimpleComponentPagination]
+  ///
+  /// The `*Label` and `*Emoji` parameters control the emojis and labels used for the pagination buttons.
   SimpleComponentPagination(
     IInteractions interactions,
     this.contentPages, {


### PR DESCRIPTION
# Description
Allow users to specify custom labels and emojis (optionally) in the paginators.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
