### PR TITLE
Toggle button state depending on position in pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 pubspec.lock
 
 .idea/
+.vscode/

--- a/lib/src/component_pagination.dart
+++ b/lib/src/component_pagination.dart
@@ -30,39 +30,60 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
   ComponentMessageBuilder initMessageBuilder() {
     final firstPageButtonId = "${customPreId}firstPage";
     final firstPageButton = ButtonBuilder("<<", firstPageButtonId, ComponentStyle.secondary);
+
+    final previousPageButtonId = "${customPreId}previousPage";
+    final previousPageButton = ButtonBuilder("<", previousPageButtonId, ComponentStyle.secondary);
+
+    final nextPageButtonId = "${customPreId}nextPage";
+    final nextPageButton = ButtonBuilder(">", nextPageButtonId, ComponentStyle.secondary);
+
+    final lastPageButtonId = "${customPreId}lastPage";
+    final lastPageButton = ButtonBuilder(">>", lastPageButtonId, ComponentStyle.secondary);
+
+    void updateButtonState() {
+      firstPageButton.disabled = currentPage == 1;
+      previousPageButton.disabled = currentPage == 1;
+      nextPageButton.disabled = currentPage == maxPage;
+      lastPageButton.disabled = currentPage == maxPage;
+    }
+
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == firstPageButtonId).listen((event) async {
       await event.acknowledge();
 
       onFirstPageButtonClicked();
+
+      updateButtonState();
       updatePage(currentPage, this.builder, event);
     });
 
-    final previousPageButtonId = "${customPreId}previousPage";
-    final previousPageButton = ButtonBuilder("<", previousPageButtonId, ComponentStyle.secondary);
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == previousPageButtonId).listen((event) async {
       await event.acknowledge();
 
       onPreviousPageButtonClicked();
+
+      updateButtonState();
       updatePage(currentPage, this.builder, event);
     });
 
-    final nextPageButtonId = "${customPreId}nextPage";
-    final nextPageButton = ButtonBuilder(">", nextPageButtonId, ComponentStyle.secondary);
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == nextPageButtonId).listen((event) async {
       await event.acknowledge();
 
       onNextPageButtonClicked();
+
+      updateButtonState();
       updatePage(currentPage, this.builder, event);
     });
 
-    final lastPageButtonId = "${customPreId}lastPage";
-    final lastPageButton = ButtonBuilder(">>", lastPageButtonId, ComponentStyle.secondary);
     interactions.events.onButtonEvent.where((event) => event.interaction.customId == lastPageButtonId).listen((event) async {
       await event.acknowledge();
 
       onLastPageButtonClicked();
+
+      updateButtonState();
       updatePage(currentPage, this.builder, event);
     });
+
+    updateButtonState();
 
     final builder = ComponentMessageBuilder()
       ..componentRows = [


### PR DESCRIPTION
# Description

Disables the pagination buttons depending on whether they will have any effect:
- "First page" and "Previous page" buttons are disabled on the first page;
- "Last page" and "Next page" buttons are disabled on the last page.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
