### PR TITLE
Allow restricting pagination to a single user

### DIFF
--- a/example/user.dart
+++ b/example/user.dart
@@ -1,0 +1,31 @@
+import "dart:async";
+
+import "package:nyxx/nyxx.dart";
+import 'package:nyxx_interactions/nyxx_interactions.dart';
+import "package:nyxx_pagination/nyxx_pagination.dart";
+
+FutureOr<void> paginationExampleInteraction(ISlashCommandInteractionEvent event) async {
+  final user = await event.interaction.memberAuthor?.user.getOrDownload() ?? event.interaction.userAuthor!;
+
+  final paginator = EmbedComponentPagination(
+    event.interactions,
+    [
+      EmbedBuilder()..description = "This is first page",
+      EmbedBuilder()..description = "This is second page",
+    ],
+    user: user,
+  );
+
+  event.respond(paginator.initMessageBuilder());
+}
+
+void main() {
+  final bot = NyxxFactory.createNyxxWebsocket("<TOKEN>", GatewayIntents.allUnprivileged);
+
+  IInteractions.create(WebsocketInteractionBackend(bot))
+    ..registerSlashCommand(SlashCommandBuilder("paginated", "This is pagination example", [], guild: 302360552993456135.toSnowflake())
+      ..registerHandler(paginationExampleInteraction))
+    ..syncOnReady();
+
+  bot.connect();
+}

--- a/lib/src/component_pagination.dart
+++ b/lib/src/component_pagination.dart
@@ -109,7 +109,7 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
       if ([firstPageButtonId, previousPageButtonId, nextPageButtonId, lastPageButtonId].contains(event.interaction.customId)) {
         await event.acknowledge();
 
-        if (user != null && (event.interaction.userAuthor ?? event.interaction.memberAuthor!.user as dynamic).id != user!.id) {
+        if (user != null && (event.interaction.userAuthor ?? event.interaction.memberAuthor!.user as SnowflakeEntity).id != user!.id) {
           await event.respond(this.builder);
 
           return;

--- a/lib/src/component_pagination.dart
+++ b/lib/src/component_pagination.dart
@@ -23,6 +23,11 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
   final IEmoji? nextEmoji;
   final IEmoji? lastEmoji;
 
+  /// The user that can use the pagination.
+  ///
+  /// Set to `null` to allow anyone to use pagination on this message.
+  final IUser? user;
+
   /// A timeout after which pagination will be disabled for this message.
   ///
   /// Set to `null` to enable pagination forever (or until bot restart).
@@ -51,6 +56,7 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
     this.nextEmoji,
     this.lastEmoji,
     this.timeout,
+    this.user,
   }) {
     customPreId = randomAlpha(10);
   }
@@ -80,6 +86,10 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
     // TODO: use ButtonInteractionEvent, currently it is not exported from nyxx_interactions
     StreamSubscription<dynamic> subscription = interactions.events.onButtonEvent.listen((event) async {
       if ([firstPageButtonId, previousPageButtonId, nextPageButtonId, lastPageButtonId].contains(event.interaction.customId)) {
+        if (user != null && (event.interaction.userAuthor ?? await event.interaction.memberAuthor!.user.getOrDownload()).id != user!.id) {
+          return;
+        }
+
         await event.acknowledge();
 
         message = event.interaction.message;
@@ -166,6 +176,7 @@ abstract class ComponentPaginationBase extends ComponentPaginationAbstract {
     IEmoji? nextEmoji,
     IEmoji? lastEmoji,
     Duration? timeout,
+    IUser? user,
   }) : super(
           interactions,
           firstLabel: firstLabel,
@@ -177,6 +188,7 @@ abstract class ComponentPaginationBase extends ComponentPaginationAbstract {
           nextEmoji: nextEmoji,
           lastEmoji: lastEmoji,
           timeout: timeout,
+          user: user,
         );
 
   @override
@@ -208,6 +220,7 @@ class EmbedComponentPagination extends ComponentPaginationBase {
     IEmoji? nextEmoji,
     IEmoji? lastEmoji,
     Duration? timeout,
+    IUser? user,
   }) : super(
           interactions,
           firstLabel: firstLabel,
@@ -219,6 +232,7 @@ class EmbedComponentPagination extends ComponentPaginationBase {
           nextEmoji: nextEmoji,
           lastEmoji: lastEmoji,
           timeout: timeout,
+          user: user,
         );
 
   @override
@@ -248,6 +262,7 @@ class SimpleComponentPagination extends ComponentPaginationBase {
     IEmoji? nextEmoji,
     IEmoji? lastEmoji,
     Duration? timeout,
+    IUser? user,
   }) : super(
           interactions,
           firstLabel: firstLabel,
@@ -259,6 +274,7 @@ class SimpleComponentPagination extends ComponentPaginationBase {
           nextEmoji: nextEmoji,
           lastEmoji: lastEmoji,
           timeout: timeout,
+          user: user,
         );
 
   @override

--- a/lib/src/component_pagination.dart
+++ b/lib/src/component_pagination.dart
@@ -109,7 +109,7 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
       if ([firstPageButtonId, previousPageButtonId, nextPageButtonId, lastPageButtonId].contains(event.interaction.customId)) {
         await event.acknowledge();
 
-        if (user != null && (event.interaction.userAuthor ?? await event.interaction.memberAuthor!.user.getOrDownload()).id != user!.id) {
+        if (user != null && (event.interaction.userAuthor ?? event.interaction.memberAuthor!.user as dynamic).id != user!.id) {
           await event.respond(this.builder);
 
           return;

--- a/lib/src/component_pagination.dart
+++ b/lib/src/component_pagination.dart
@@ -86,11 +86,13 @@ abstract class ComponentPaginationAbstract extends IPagination<IButtonInteractio
     // TODO: use ButtonInteractionEvent, currently it is not exported from nyxx_interactions
     StreamSubscription<dynamic> subscription = interactions.events.onButtonEvent.listen((event) async {
       if ([firstPageButtonId, previousPageButtonId, nextPageButtonId, lastPageButtonId].contains(event.interaction.customId)) {
+        await event.acknowledge();
+
         if (user != null && (event.interaction.userAuthor ?? await event.interaction.memberAuthor!.user.getOrDownload()).id != user!.id) {
+          await event.respond(this.builder);
+
           return;
         }
-
-        await event.acknowledge();
 
         message = event.interaction.message;
 


### PR DESCRIPTION
# Description

Allow restricting pagination to a single user, preventing other users from messing with someone else's paginated message.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
